### PR TITLE
Move gulp to a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "d3-scale": "^3.0.0",
     "d3-selection": "^1.4.0",
     "d3-shape": "^1.3.5",
-    "d3-transition": "^1.2.0",
-    "gulp": "^4.0.0"
+    "d3-transition": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
@@ -39,6 +38,7 @@
     "chai": "^4.2.0",
     "d3": "^5.9.2",
     "eslint": "^5.16.0",
+    "gulp": "^4.0.0",
     "gulp-babel": "^8.0.0",
     "gulp-rename": "^1.4.0",
     "gulp-uglify": "^3.0.2",


### PR DESCRIPTION
There is no reason to install gulp when using this package.